### PR TITLE
chore: ship the PEP 561 py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
 ]
 keywords = ["machine unlearning", "machine learning", "deep learning", "computer vision"]
 packages = [{ include = "vision_unlearning" }]
+# PEP 561: ship the py.typed marker so type checkers use this package's inline annotations.
+include = [{ path = "vision_unlearning/py.typed", format = ["sdist", "wheel"] }]
 exclude = ["tests", "docs", "examples"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## What

Adds `vision_unlearning/py.typed` (PEP 561) and includes it in the built sdist/wheel via `pyproject.toml`.

## Why

Without this marker, every type checker treats this package as fully untyped from the outside: any value crossing the import boundary (e.g. `rt_name_to_class[template](**params)`, `InterferencePerEntity(...).compute()`) resolves to `Any`, so a caller passing a wrong argument type or misusing a return value gets no mypy signal at all. Confirmed empirically: a probe script calling `convert_params_from_gui_to_backend` with a wrong argument type produces zero mypy errors before this change, two clear errors after (with the package on `PYTHONPATH`, matching how forgety consumes it today).

## Verification

- `forgety`: offline pytest suite (63 tests) and `libs`/`services/backend/app` mypy — both clean against the typed package.
- `vision-unlearning` lite tier (`make test-lite` equivalent): mypy (55 files), pycodestyle, pytest (229 passed / 4 skipped) all clean.
- `poetry check --lock`: lock file still valid after the `pyproject.toml` include addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)