### PR TITLE
Register InterferenceVisualSummary in the RT runner CLI, unify HF upload/skip logic

### DIFF
--- a/tests/test_pipeline_08_run_all_rts.py
+++ b/tests/test_pipeline_08_run_all_rts.py
@@ -113,22 +113,29 @@ class TestShouldSkip:
 
 
 class TestComputeAndReport:
+    """``_compute_and_report`` takes a zero-argument ``rt_factory`` (not an already-built
+    RT) precisely so that construction errors are caught by the same handler as
+    ``compute()`` errors -- see ``test_logs_and_continues_on_construction_failure``.
+    """
+
     def test_local_hit_skips_compute(self, tmp_path: Any, capsys: Any) -> None:
         local = tmp_path / "present.json"
         local.write_text("{}")
         rt = _FakeRT(local_path=str(local))
-        _compute_and_report(cast(Any, rt), frozenset(), False, "context")
+        _compute_and_report(lambda: cast(Any, rt), frozenset(), False, "context")
         assert rt.compute_called is False
         assert capsys.readouterr().out == ""
 
     def test_hf_hit_skips_compute(self, tmp_path: Any) -> None:
         rt = _FakeRT(local_path=str(tmp_path / "missing.json"), remote_path="results/Fake/x.json")
-        _compute_and_report(cast(Any, rt), frozenset({"results/Fake/x.json"}), False, "context")
+        _compute_and_report(
+            lambda: cast(Any, rt), frozenset({"results/Fake/x.json"}), False, "context"
+        )
         assert rt.compute_called is False
 
     def test_computes_and_prints_marker_on_success(self, tmp_path: Any, capsys: Any) -> None:
         rt = _FakeRT(local_path=str(tmp_path / "missing.json"))
-        _compute_and_report(cast(Any, rt), frozenset(), False, "context")
+        _compute_and_report(lambda: cast(Any, rt), frozenset(), False, "context")
         assert rt.compute_called is True
         assert capsys.readouterr().out == "."
 
@@ -140,15 +147,25 @@ class TestComputeAndReport:
 
         rt = _FakeRT(local_path=str(tmp_path / "missing.json"), compute_fn=_boom)
         with caplog.at_level(logging.WARNING):
-            _compute_and_report(cast(Any, rt), frozenset(), False, "my-context")
+            _compute_and_report(lambda: cast(Any, rt), frozenset(), False, "my-context")
         assert "my-context failed: boom" in caplog.text
+
+    def test_logs_and_continues_on_construction_failure(self, caplog: Any) -> None:
+        """A failure while building the RT (e.g. pydantic validation) must be caught
+        by the same handler as a compute() failure, not propagate and abort the run."""
+        def _factory() -> Any:
+            raise ValueError("bad constructor args")
+
+        with caplog.at_level(logging.WARNING):
+            _compute_and_report(_factory, frozenset(), False, "my-context")
+        assert "my-context failed: bad constructor args" in caplog.text
 
     def test_recomputes_when_upload_if_recomputed_but_not_yet_on_hf(
         self, tmp_path: Any
     ) -> None:
         """upload_if_recomputed alone (no local, no HF hit) does not shortcut compute()."""
         rt = _FakeRT(local_path=str(tmp_path / "missing.json"))
-        _compute_and_report(cast(Any, rt), frozenset(), True, "context")
+        _compute_and_report(lambda: cast(Any, rt), frozenset(), True, "context")
         assert rt.compute_called is True
 
 

--- a/tests/test_pipeline_08_run_all_rts.py
+++ b/tests/test_pipeline_08_run_all_rts.py
@@ -1,0 +1,199 @@
+"""Tests for pipeline_08_run_all_rts (pure logic — no network, no GPU, no torch).
+
+``_should_skip`` and ``_compute_and_report`` only rely on the duck-typed interface a
+Result Template exposes (``_get_data_path_local``, ``_get_data_path_remote``,
+``remote_repository_name``, ``compute``), so a lightweight fake stands in for the real
+(pydantic, torch-adjacent) ``ResultTemplate`` subclasses.
+"""
+import logging
+from typing import Any, Callable, FrozenSet, List, Optional, cast
+
+import pytest
+
+from vision_unlearning.benchmarks.I_care.pipeline_08_run_all_rts import (
+    _compute_and_report,
+    _should_skip,
+    parse_args,
+    resolve_rt_names,
+)
+
+
+class _FakeRT:
+    """Minimal stand-in for a ``ResultTemplate`` subclass.
+
+    Exposes exactly the surface ``_should_skip``/``_compute_and_report`` use, so tests
+    do not need to instantiate a real (heavy) Result Template.
+    """
+
+    def __init__(
+        self,
+        local_path: str,
+        remote_path: str = "results/Fake/x.json",
+        compute_fn: Optional[Callable[[], dict]] = None,
+        remote_repository_name: str = "some/repo",
+    ) -> None:
+        self._local_path = local_path
+        self._remote_path = remote_path
+        self.remote_repository_name = remote_repository_name
+        self._compute_fn = compute_fn or (lambda: {"result": {}})
+        self.compute_called = False
+
+    def _get_data_path_local(self) -> str:
+        return self._local_path
+
+    def _get_data_path_remote(self) -> str:
+        return self._remote_path
+
+    def compute(self) -> dict:
+        self.compute_called = True
+        return self._compute_fn()
+
+
+class TestShouldSkip:
+    def test_returns_false_when_absent_locally_and_remotely(self, tmp_path: Any) -> None:
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"))
+        assert _should_skip(cast(Any, rt), hf_files=frozenset(), upload_if_recomputed=False) is False
+
+    def test_returns_true_when_present_locally(self, tmp_path: Any) -> None:
+        local = tmp_path / "present.json"
+        local.write_text("{}")
+        rt = _FakeRT(local_path=str(local))
+        assert _should_skip(cast(Any, rt), hf_files=frozenset(), upload_if_recomputed=False) is True
+
+    def test_returns_true_when_present_on_hf(self, tmp_path: Any) -> None:
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"), remote_path="results/Fake/x.json")
+        hf_files: FrozenSet[str] = frozenset({"results/Fake/x.json"})
+        assert _should_skip(cast(Any, rt), hf_files=hf_files, upload_if_recomputed=False) is True
+
+    def test_local_hit_does_not_upload_without_hf_token(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """upload_if_recomputed=True but HF_TOKEN unset: skip is reported, no upload attempted."""
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        local = tmp_path / "present.json"
+        local.write_text("{}")
+        rt = _FakeRT(local_path=str(local), remote_path="results/Fake/x.json")
+        result = _should_skip(cast(Any, rt), hf_files=frozenset(), upload_if_recomputed=True)
+        assert result is True
+
+    def test_local_hit_uploads_when_not_yet_on_hf_and_token_set(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("HF_TOKEN", "fake-token")
+        uploaded: List[dict] = []
+        monkeypatch.setattr(
+            "vision_unlearning.integrations.huggingface.huggingface_dataset_file_upload",
+            lambda **kw: uploaded.append(kw),
+        )
+        local = tmp_path / "present.json"
+        local.write_text("{}")
+        rt = _FakeRT(local_path=str(local), remote_path="results/Fake/x.json")
+        result = _should_skip(cast(Any, rt), hf_files=frozenset(), upload_if_recomputed=True)
+        assert result is True
+        assert len(uploaded) == 1
+        assert uploaded[0]["dataset_path"] == "results/Fake/x.json"
+
+    def test_local_hit_skips_upload_when_already_on_hf(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("HF_TOKEN", "fake-token")
+        uploaded: List[dict] = []
+        monkeypatch.setattr(
+            "vision_unlearning.integrations.huggingface.huggingface_dataset_file_upload",
+            lambda **kw: uploaded.append(kw),
+        )
+        local = tmp_path / "present.json"
+        local.write_text("{}")
+        rt = _FakeRT(local_path=str(local), remote_path="results/Fake/x.json")
+        result = _should_skip(
+            cast(Any, rt), hf_files=frozenset({"results/Fake/x.json"}), upload_if_recomputed=True
+        )
+        assert result is True
+        assert uploaded == []
+
+
+class TestComputeAndReport:
+    def test_local_hit_skips_compute(self, tmp_path: Any, capsys: Any) -> None:
+        local = tmp_path / "present.json"
+        local.write_text("{}")
+        rt = _FakeRT(local_path=str(local))
+        _compute_and_report(cast(Any, rt), frozenset(), False, "context")
+        assert rt.compute_called is False
+        assert capsys.readouterr().out == ""
+
+    def test_hf_hit_skips_compute(self, tmp_path: Any) -> None:
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"), remote_path="results/Fake/x.json")
+        _compute_and_report(cast(Any, rt), frozenset({"results/Fake/x.json"}), False, "context")
+        assert rt.compute_called is False
+
+    def test_computes_and_prints_marker_on_success(self, tmp_path: Any, capsys: Any) -> None:
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"))
+        _compute_and_report(cast(Any, rt), frozenset(), False, "context")
+        assert rt.compute_called is True
+        assert capsys.readouterr().out == "."
+
+    def test_logs_and_continues_on_compute_failure(
+        self, tmp_path: Any, caplog: Any
+    ) -> None:
+        def _boom() -> dict:
+            raise RuntimeError("boom")
+
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"), compute_fn=_boom)
+        with caplog.at_level(logging.WARNING):
+            _compute_and_report(cast(Any, rt), frozenset(), False, "my-context")
+        assert "my-context failed: boom" in caplog.text
+
+    def test_recomputes_when_upload_if_recomputed_but_not_yet_on_hf(
+        self, tmp_path: Any
+    ) -> None:
+        """upload_if_recomputed alone (no local, no HF hit) does not shortcut compute()."""
+        rt = _FakeRT(local_path=str(tmp_path / "missing.json"))
+        _compute_and_report(cast(Any, rt), frozenset(), True, "context")
+        assert rt.compute_called is True
+
+
+class TestResolveRtNames:
+    def test_matches_interference_visual_summary(self) -> None:
+        assert resolve_rt_names(["InterferenceVisualSummary"]) == ["interferencevisualsummary"]
+
+    def test_all_keyword_returns_full_registered_list(self) -> None:
+        from vision_unlearning.benchmarks.I_care.pipeline_08_run_all_rts import ALL_RT_NAMES
+        assert resolve_rt_names(["all"]) == ALL_RT_NAMES
+        assert "interferencevisualsummary" in ALL_RT_NAMES
+        assert "unlearningvisualsummary" not in ALL_RT_NAMES
+
+    def test_unmatched_name_returns_empty_and_warns(self, caplog: Any) -> None:
+        with caplog.at_level(logging.WARNING):
+            result = resolve_rt_names(["NotARealRT"])
+        assert result == []
+        assert "did not match any known RT" in caplog.text
+
+
+class TestMpArgument:
+    def test_defaults_to_all_five_metrics(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("sys.argv", ["pipeline_08_run_all_rts.py"])
+        args = parse_args()
+        assert set(args.mp) == {"brisque_diff", "clip_diff", "rmse", "ssim", "dino_diff"}
+
+    def test_restricts_to_requested_metric(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("sys.argv", ["pipeline_08_run_all_rts.py", "--mp", "clip_diff"])
+        args = parse_args()
+        assert args.mp == ["clip_diff"]
+
+    def test_accepts_multiple_metrics(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "sys.argv", ["pipeline_08_run_all_rts.py", "--mp", "clip_diff", "ssim"]
+        )
+        args = parse_args()
+        assert args.mp == ["clip_diff", "ssim"]
+
+    def test_rejects_unknown_metric(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "sys.argv", ["pipeline_08_run_all_rts.py", "--mp", "not_a_real_metric"]
+        )
+        with pytest.raises(SystemExit):
+            parse_args()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
+++ b/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-from typing import FrozenSet, List, Optional, cast, get_args
+from typing import Callable, FrozenSet, List, Optional, cast, get_args
 
 logging.basicConfig(
     level=logging.INFO,
@@ -151,23 +151,30 @@ def _should_skip(
 
 
 def _compute_and_report(
-    rt: "vb.ResultTemplate",  # type: ignore[name-defined]
+    rt_factory: Callable[[], "vb.ResultTemplate"],  # type: ignore[name-defined]
     hf_files: FrozenSet[str],
     upload_if_recomputed: bool,
     error_context: str,
 ) -> None:
-    """Skip if the result already exists locally or on HuggingFace; otherwise compute it.
+    """Construct and skip/compute one RT, warning and continuing on any failure.
 
-    Centralizes the skip-check, compute, progress marker, and warn-and-continue behavior
-    every RT runner needs, so upload/skip semantics cannot be forgotten case-by-case.
+    Centralizes the construct, skip-check, compute, progress marker, and
+    warn-and-continue behavior every RT runner needs, so upload/skip semantics cannot
+    be forgotten case-by-case. ``rt_factory`` is a zero-argument callable rather than an
+    already-built RT so that construction errors (e.g. pydantic validation) are caught
+    by the same handler as compute() errors, instead of aborting the whole CLI run.
+    Callers pass a lambda closing over the current loop variables; since
+    ``rt_factory()`` is invoked synchronously (not deferred/stored), the closures are
+    evaluated immediately and are not subject to the late-binding-in-loops pitfall.
     """
     try:
+        rt = rt_factory()
         if _should_skip(rt, hf_files, upload_if_recomputed):
             return
         rt.compute()
         print(".", end="", flush=True)
     except Exception as exc:
-        logger.warning("%s failed: %s", error_context, exc)
+        logger.warning("%s failed: %s", error_context, exc, exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -187,17 +194,17 @@ def run_metric_metric_alignment(
             for unlearning_algorithm in methods:
                 for i, me1 in enumerate(me_list):
                     for me2 in me_list[i + 1:]:
-                        rt = vb.ResultTemplateMetricMetricAlignment(  # type: ignore[arg-type]
-                            model=model,
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                            interference_entity_1=me1,
-                            interference_entity_2=me2,
-                            upload_if_recomputed=upload_if_recomputed,
-                            save_outputs=True,
-                        )
                         _compute_and_report(
-                            rt, hf_files, upload_if_recomputed,
+                            lambda: vb.ResultTemplateMetricMetricAlignment(  # type: ignore[arg-type]
+                                model=model,
+                                task=task,  # type: ignore[arg-type]
+                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                                interference_entity_1=me1,
+                                interference_entity_2=me2,
+                                upload_if_recomputed=upload_if_recomputed,
+                                save_outputs=True,
+                            ),
+                            hf_files, upload_if_recomputed,
                             f"MetricMetricAlignment for {model}/{task}/{unlearning_algorithm}/{me1}/{me2}",
                         )
                 print("")
@@ -217,17 +224,17 @@ def run_metric_similarity_alignment(
             for unlearning_algorithm in methods:
                 for interference_pair in mp_list:
                     for similarity_metric in _ALL_S:
-                        rt = vb.ResultTemplateMetricSimilarityAlignment(  # type: ignore[arg-type]
-                            model=model,
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                            interference_pair=interference_pair,
-                            similarity_metric=similarity_metric,
-                            upload_if_recomputed=upload_if_recomputed,
-                            save_outputs=True,
-                        )
                         _compute_and_report(
-                            rt, hf_files, upload_if_recomputed,
+                            lambda: vb.ResultTemplateMetricSimilarityAlignment(  # type: ignore[arg-type]
+                                model=model,
+                                task=task,  # type: ignore[arg-type]
+                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                                interference_pair=interference_pair,
+                                similarity_metric=similarity_metric,
+                                upload_if_recomputed=upload_if_recomputed,
+                                save_outputs=True,
+                            ),
+                            hf_files, upload_if_recomputed,
                             f"MetricSimilarityAlignment for {model}/{task}/{unlearning_algorithm}/"
                             f"{interference_pair}/{similarity_metric}",
                         )
@@ -258,20 +265,20 @@ def run_metric_similarity_alignment_multi(
                 for interference_pair in mp_list:
                     for similarity_metric_list in similarity_sets:
                         for regression_algorithm in regression_algorithms:
-                            rt = vb.ResultTemplateMetricSimilarityAlignmentMulti(
-                                model=model,
-                                task=task,  # type: ignore[arg-type]
-                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                                interference_pair=interference_pair,
-                                similarity_metric_list=similarity_metric_list,
-                                include_emitter_forget_quality=True,
-                                include_baseline_quality=True,
-                                regression_algorithm=regression_algorithm,  # type: ignore[arg-type]
-                                upload_if_recomputed=upload_if_recomputed,
-                                save_outputs=True,
-                            )
                             _compute_and_report(
-                                rt, hf_files, upload_if_recomputed,
+                                lambda: vb.ResultTemplateMetricSimilarityAlignmentMulti(
+                                    model=model,
+                                    task=task,  # type: ignore[arg-type]
+                                    unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                                    interference_pair=interference_pair,
+                                    similarity_metric_list=similarity_metric_list,
+                                    include_emitter_forget_quality=True,
+                                    include_baseline_quality=True,
+                                    regression_algorithm=regression_algorithm,  # type: ignore[arg-type]
+                                    upload_if_recomputed=upload_if_recomputed,
+                                    save_outputs=True,
+                                ),
+                                hf_files, upload_if_recomputed,
                                 f"MetricSimilarityAlignmentMulti for {model}/{task}/"
                                 f"{unlearning_algorithm}/{interference_pair}/"
                                 f"{similarity_metric_list}/{regression_algorithm}",
@@ -292,16 +299,16 @@ def run_interference_matrix(
         for task in tasks:
             for unlearning_algorithm in methods:
                 for interference_pair in mp_list:
-                    rt = vb.ResultTemplateInterferenceMatrix(  # type: ignore[arg-type]
-                        model=model,
-                        task=task,  # type: ignore[arg-type]
-                        unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                        interference_pair=interference_pair,
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
                     _compute_and_report(
-                        rt, hf_files, upload_if_recomputed,
+                        lambda: vb.ResultTemplateInterferenceMatrix(  # type: ignore[arg-type]
+                            model=model,
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                            interference_pair=interference_pair,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        ),
+                        hf_files, upload_if_recomputed,
                         f"InterferenceMatrix for {model}/{task}/{unlearning_algorithm}/{interference_pair}",
                     )
                 print("")
@@ -317,15 +324,15 @@ def run_similarity_matrix(
     for model in _ALL_MODELS:
         for task in tasks:
             for similarity_metric in _ALL_S:
-                rt = vb.ResultTemplateSimilarityMatrix(
-                    model=model,
-                    task=task,  # type: ignore[arg-type]
-                    similarity_metric=similarity_metric,
-                    upload_if_recomputed=upload_if_recomputed,
-                    save_outputs=True,
-                )
                 _compute_and_report(
-                    rt, hf_files, upload_if_recomputed,
+                    lambda: vb.ResultTemplateSimilarityMatrix(
+                        model=model,
+                        task=task,  # type: ignore[arg-type]
+                        similarity_metric=similarity_metric,
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    ),
+                    hf_files, upload_if_recomputed,
                     f"SimilarityMatrix for {model}/{task}/{similarity_metric}",
                 )
         print("")
@@ -430,17 +437,17 @@ def run_count_significant_relationship(
     me_list = _ALL_ME
     for model in _ALL_MODELS:
         for task in tasks:
-            rt = vb.ResultTemplateCountSignificantRelationship(
-                model=model,
-                task=task,  # type: ignore[arg-type]
-                unlearning_algorithm_list=methods,  # type: ignore[arg-type]
-                interference_entity_list=me_list,
-                attribute_list=list(vb.task_to_attributes_of_interest.get(task, [])),
-                upload_if_recomputed=upload_if_recomputed,
-                save_outputs=True,
-            )
             _compute_and_report(
-                rt, hf_files, upload_if_recomputed,
+                lambda: vb.ResultTemplateCountSignificantRelationship(
+                    model=model,
+                    task=task,  # type: ignore[arg-type]
+                    unlearning_algorithm_list=methods,  # type: ignore[arg-type]
+                    interference_entity_list=me_list,
+                    attribute_list=list(vb.task_to_attributes_of_interest.get(task, [])),
+                    upload_if_recomputed=upload_if_recomputed,
+                    save_outputs=True,
+                ),
+                hf_files, upload_if_recomputed,
                 f"CountSignificantRelationship for {model}/{task}",
             )
     print("CountSignificantRelationship done.")
@@ -474,18 +481,18 @@ def run_implicit_association_test(
             for unlearning_algorithm in methods:
                 for latent_embedding in _ALL_L:
                     for attr1, attr2 in attribute_pairs:
-                        rt = vb.ResultTemplateImplicitAssociationTest(  # type: ignore[arg-type]
-                            model=model,
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                            attribute_1=attr1,
-                            attribute_2=attr2,
-                            latent_embedding=latent_embedding,
-                            upload_if_recomputed=upload_if_recomputed,
-                            save_outputs=True,
-                        )
                         _compute_and_report(
-                            rt, hf_files, upload_if_recomputed,
+                            lambda: vb.ResultTemplateImplicitAssociationTest(  # type: ignore[arg-type]
+                                model=model,
+                                task=task,  # type: ignore[arg-type]
+                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                                attribute_1=attr1,
+                                attribute_2=attr2,
+                                latent_embedding=latent_embedding,
+                                upload_if_recomputed=upload_if_recomputed,
+                                save_outputs=True,
+                            ),
+                            hf_files, upload_if_recomputed,
                             f"ImplicitAssociationTest for {model}/{task}/{unlearning_algorithm}/"
                             f"{latent_embedding}/{attr1}/{attr2}",
                         )
@@ -532,17 +539,17 @@ def run_interference_visual_summary(
         for unlearning_algorithm in methods:
             for interference_pair in mp_list:
                 for entity_index in range(entity_count):
-                    rt = vb.ResultTemplateInterferenceVisualSummary(  # type: ignore[arg-type]
-                        task=task,  # type: ignore[arg-type]
-                        unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                        interference_pair=interference_pair,
-                        entity_index=entity_index,
-                        seed=42,
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
                     _compute_and_report(
-                        rt, hf_files, upload_if_recomputed,
+                        lambda: vb.ResultTemplateInterferenceVisualSummary(  # type: ignore[arg-type]
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                            interference_pair=interference_pair,
+                            entity_index=entity_index,
+                            seed=42,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        ),
+                        hf_files, upload_if_recomputed,
                         f"InterferenceVisualSummary for {task}/{unlearning_algorithm}/"
                         f"{interference_pair} entity={entity_index}",
                     )
@@ -565,16 +572,16 @@ def run_method_comparison_by_metric_entity(
     for model in _ALL_MODELS:
         for task in tasks:
             for interference_entity in me_list:
-                rt = vb.ResultTemplateMethodComparisonByMetricEntity(
-                    model=model,
-                    task=task,  # type: ignore[arg-type]
-                    interference_entity=interference_entity,
-                    unlearning_algorithm_list=methods,  # type: ignore[arg-type]
-                    upload_if_recomputed=upload_if_recomputed,
-                    save_outputs=True,
-                )
                 _compute_and_report(
-                    rt, hf_files, upload_if_recomputed,
+                    lambda: vb.ResultTemplateMethodComparisonByMetricEntity(
+                        model=model,
+                        task=task,  # type: ignore[arg-type]
+                        interference_entity=interference_entity,
+                        unlearning_algorithm_list=methods,  # type: ignore[arg-type]
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    ),
+                    hf_files, upload_if_recomputed,
                     f"MethodComparisonByMetricEntity for {model}/{task}/{interference_entity}",
                 )
         print("")
@@ -601,16 +608,16 @@ def run_embedding_unlearning_profile(
             for method in methods:
                 for row in metadata:
                     entity = row["name"]
-                    rt = vb.ResultTemplateEmbeddingUnlearningProfile(
-                        model=model,
-                        task=task,  # type: ignore[arg-type]
-                        unlearning_algorithm=method,  # type: ignore[arg-type]
-                        entity=entity,
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
                     _compute_and_report(
-                        rt, hf_files, upload_if_recomputed,
+                        lambda: vb.ResultTemplateEmbeddingUnlearningProfile(
+                            model=model,
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=method,  # type: ignore[arg-type]
+                            entity=entity,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        ),
+                        hf_files, upload_if_recomputed,
                         f"EmbeddingUnlearningProfile for {model}/{task}/{method}/{entity}",
                     )
                 print("")
@@ -630,15 +637,15 @@ def run_embedding_forgetting_efficiency(
     for model in _ALL_MODELS:
         for task in tasks:
             for method in methods:
-                rt = vb.ResultTemplateEmbeddingForgettingEfficiency(
-                    model=model,
-                    task=task,  # type: ignore[arg-type]
-                    unlearning_algorithm=method,  # type: ignore[arg-type]
-                    upload_if_recomputed=upload_if_recomputed,
-                    save_outputs=True,
-                )
                 _compute_and_report(
-                    rt, hf_files, upload_if_recomputed,
+                    lambda: vb.ResultTemplateEmbeddingForgettingEfficiency(
+                        model=model,
+                        task=task,  # type: ignore[arg-type]
+                        unlearning_algorithm=method,  # type: ignore[arg-type]
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    ),
+                    hf_files, upload_if_recomputed,
                     f"EmbeddingForgettingEfficiency for {model}/{task}/{method}",
                 )
         print("")

--- a/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
+++ b/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
@@ -5,6 +5,7 @@ Usage
     python pipeline_08_run_all_rts.py --rts all
     python pipeline_08_run_all_rts.py --rts SignificantRelationship CountSignificantRelationship
     python pipeline_08_run_all_rts.py --rts InterferenceMatrix --tasks people --methods distil
+    python pipeline_08_run_all_rts.py --rts InterferenceVisualSummary --mp clip_diff
 
 RT names accepted (short form, case-insensitive):
     MetricMetricAlignment
@@ -15,11 +16,21 @@ RT names accepted (short form, case-insensitive):
     CountSignificantRelationship
     ImplicitAssociationTest
     MinimumCutInterference          (skipped — too many combos, computed on-demand)
-    UnlearningVisualSummary
     InterferenceVisualSummary
     MethodComparisonByMetricEntity
     EmbeddingUnlearningProfile      (per task-method-entity; requires DINOv2 embedding files)
     EmbeddingForgettingEfficiency   (per task-method; requires interference_per_entity)
+
+    UnlearningVisualSummary is not in ``ALL_RT_NAMES``:
+    ``ResultTemplateUnlearningVisualSummary`` is an unimplemented stub
+    (``.compute()`` raises ``NotImplementedError``) and is not used anywhere in
+    Forgety's entity-browsing flow.
+
+``--mp`` restricts which per-pair interference metric(s) are computed for
+InterferenceMatrix, MetricSimilarityAlignment(Multi), and InterferenceVisualSummary
+(default: all 5). Forgety's entity-browsing flow only ever displays
+``interference_pair="clip_diff"``, so a cluster run backing that flow only needs
+``--mp clip_diff``.
 
 By default (``--upload-if-recomputed``) each newly computed RT result is uploaded to
 HuggingFace immediately after computation.  Set ``HF_TOKEN`` in the environment.
@@ -139,6 +150,26 @@ def _should_skip(
     return False
 
 
+def _compute_and_report(
+    rt: "vb.ResultTemplate",  # type: ignore[name-defined]
+    hf_files: FrozenSet[str],
+    upload_if_recomputed: bool,
+    error_context: str,
+) -> None:
+    """Skip if the result already exists locally or on HuggingFace; otherwise compute it.
+
+    Centralizes the skip-check, compute, progress marker, and warn-and-continue behavior
+    every RT runner needs, so upload/skip semantics cannot be forgotten case-by-case.
+    """
+    try:
+        if _should_skip(rt, hf_files, upload_if_recomputed):
+            return
+        rt.compute()
+        print(".", end="", flush=True)
+    except Exception as exc:
+        logger.warning("%s failed: %s", error_context, exc)
+
+
 # ---------------------------------------------------------------------------
 # RT runner functions — one per RT (or group of RTs)
 # ---------------------------------------------------------------------------
@@ -156,25 +187,19 @@ def run_metric_metric_alignment(
             for unlearning_algorithm in methods:
                 for i, me1 in enumerate(me_list):
                     for me2 in me_list[i + 1:]:
-                        try:
-                            rt = vb.ResultTemplateMetricMetricAlignment(  # type: ignore[arg-type]
-                                model=model,
-                                task=task,  # type: ignore[arg-type]
-                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                                interference_entity_1=me1,
-                                interference_entity_2=me2,
-                                upload_if_recomputed=upload_if_recomputed,
-                                save_outputs=True,
-                            )
-                            if _should_skip(rt, hf_files, upload_if_recomputed):
-                                continue
-                            rt.compute()
-                            print(".", end="", flush=True)
-                        except Exception as e:
-                            logger.warning(
-                                "MetricMetricAlignment failed for %s/%s/%s/%s/%s: %s",
-                                model, task, unlearning_algorithm, me1, me2, e,
-                            )
+                        rt = vb.ResultTemplateMetricMetricAlignment(  # type: ignore[arg-type]
+                            model=model,
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                            interference_entity_1=me1,
+                            interference_entity_2=me2,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        )
+                        _compute_and_report(
+                            rt, hf_files, upload_if_recomputed,
+                            f"MetricMetricAlignment for {model}/{task}/{unlearning_algorithm}/{me1}/{me2}",
+                        )
                 print("")
     print("MetricMetricAlignment done.")
 
@@ -184,33 +209,28 @@ def run_metric_similarity_alignment(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
+    mp_list: List[vb.type_mp] = _ALL_MP,
 ) -> None:
     """MetricSimilarityAlignment: (model, task, unlearning_algorithm, mp, s)."""
     for model in _ALL_MODELS:
         for task in tasks:
             for unlearning_algorithm in methods:
-                for interference_pair in _ALL_MP:
+                for interference_pair in mp_list:
                     for similarity_metric in _ALL_S:
-                        try:
-                            rt = vb.ResultTemplateMetricSimilarityAlignment(  # type: ignore[arg-type]
-                                model=model,
-                                task=task,  # type: ignore[arg-type]
-                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                                interference_pair=interference_pair,
-                                similarity_metric=similarity_metric,
-                                upload_if_recomputed=upload_if_recomputed,
-                                save_outputs=True,
-                            )
-                            if _should_skip(rt, hf_files, upload_if_recomputed):
-                                continue
-                            rt.compute()
-                            print(".", end="", flush=True)
-                        except Exception as e:
-                            logger.warning(
-                                "MetricSimilarityAlignment failed for %s/%s/%s/%s/%s: %s",
-                                model, task, unlearning_algorithm, interference_pair,
-                                similarity_metric, e,
-                            )
+                        rt = vb.ResultTemplateMetricSimilarityAlignment(  # type: ignore[arg-type]
+                            model=model,
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                            interference_pair=interference_pair,
+                            similarity_metric=similarity_metric,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        )
+                        _compute_and_report(
+                            rt, hf_files, upload_if_recomputed,
+                            f"MetricSimilarityAlignment for {model}/{task}/{unlearning_algorithm}/"
+                            f"{interference_pair}/{similarity_metric}",
+                        )
                 print("")
     print("MetricSimilarityAlignment done.")
 
@@ -220,6 +240,7 @@ def run_metric_similarity_alignment_multi(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
+    mp_list: List[vb.type_mp] = _ALL_MP,
 ) -> None:
     """MetricSimilarityAlignmentMulti: (model, task, unlearning_algorithm, mp, s_list, reg_algo).
 
@@ -234,33 +255,27 @@ def run_metric_similarity_alignment_multi(
     for model in _ALL_MODELS:
         for task in tasks:
             for unlearning_algorithm in methods:
-                for interference_pair in _ALL_MP:
+                for interference_pair in mp_list:
                     for similarity_metric_list in similarity_sets:
                         for regression_algorithm in regression_algorithms:
-                            try:
-                                rt = vb.ResultTemplateMetricSimilarityAlignmentMulti(
-                                    model=model,
-                                    task=task,  # type: ignore[arg-type]
-                                    unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                                    interference_pair=interference_pair,
-                                    similarity_metric_list=similarity_metric_list,
-                                    include_emitter_forget_quality=True,
-                                    include_baseline_quality=True,
-                                    regression_algorithm=regression_algorithm,  # type: ignore[arg-type]
-                                    upload_if_recomputed=upload_if_recomputed,
-                                    save_outputs=True,
-                                )
-                                if _should_skip(rt, hf_files, upload_if_recomputed):
-                                    continue
-                                rt.compute()
-                                print(".", end="", flush=True)
-                            except Exception as e:
-                                logger.warning(
-                                    "MetricSimilarityAlignmentMulti failed for "
-                                    "%s/%s/%s/%s/%s/%s: %s",
-                                    model, task, unlearning_algorithm, interference_pair,
-                                    similarity_metric_list, regression_algorithm, e,
-                                )
+                            rt = vb.ResultTemplateMetricSimilarityAlignmentMulti(
+                                model=model,
+                                task=task,  # type: ignore[arg-type]
+                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                                interference_pair=interference_pair,
+                                similarity_metric_list=similarity_metric_list,
+                                include_emitter_forget_quality=True,
+                                include_baseline_quality=True,
+                                regression_algorithm=regression_algorithm,  # type: ignore[arg-type]
+                                upload_if_recomputed=upload_if_recomputed,
+                                save_outputs=True,
+                            )
+                            _compute_and_report(
+                                rt, hf_files, upload_if_recomputed,
+                                f"MetricSimilarityAlignmentMulti for {model}/{task}/"
+                                f"{unlearning_algorithm}/{interference_pair}/"
+                                f"{similarity_metric_list}/{regression_algorithm}",
+                            )
                 print("")
     print("MetricSimilarityAlignmentMulti done.")
 
@@ -270,31 +285,26 @@ def run_interference_matrix(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
+    mp_list: List[vb.type_mp] = _ALL_MP,
 ) -> None:
     """InterferenceMatrix: (model, task, unlearning_algorithm, interference_pair)."""
     for model in _ALL_MODELS:
         for task in tasks:
             for unlearning_algorithm in methods:
-                for interference_pair in _ALL_MP:
-                    try:
-                        rt = vb.ResultTemplateInterferenceMatrix(  # type: ignore[arg-type]
-                            model=model,
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                            interference_pair=interference_pair,
-                            upload_if_recomputed=upload_if_recomputed,
-                            save_outputs=True,
-                        )
-                        if _should_skip(rt, hf_files, upload_if_recomputed):
-                            continue
-                        rt.compute()
-                        print(".", end="", flush=True)
-                    except Exception as e:
-                        logger.warning(
-                            "InterferenceMatrix failed for %s/%s/%s/%s: %s",
-                            model, task, unlearning_algorithm, interference_pair, e,
-                        )
-            print("")
+                for interference_pair in mp_list:
+                    rt = vb.ResultTemplateInterferenceMatrix(  # type: ignore[arg-type]
+                        model=model,
+                        task=task,  # type: ignore[arg-type]
+                        unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                        interference_pair=interference_pair,
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    )
+                    _compute_and_report(
+                        rt, hf_files, upload_if_recomputed,
+                        f"InterferenceMatrix for {model}/{task}/{unlearning_algorithm}/{interference_pair}",
+                    )
+                print("")
     print("InterferenceMatrix done.")
 
 
@@ -307,23 +317,17 @@ def run_similarity_matrix(
     for model in _ALL_MODELS:
         for task in tasks:
             for similarity_metric in _ALL_S:
-                try:
-                    rt = vb.ResultTemplateSimilarityMatrix(
-                        model=model,
-                        task=task,  # type: ignore[arg-type]
-                        similarity_metric=similarity_metric,
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
-                    if _should_skip(rt, hf_files, upload_if_recomputed):
-                        continue
-                    rt.compute()
-                    print(".", end="", flush=True)
-                except Exception as e:
-                    logger.warning(
-                        "SimilarityMatrix failed for %s/%s/%s: %s",
-                        model, task, similarity_metric, e,
-                    )
+                rt = vb.ResultTemplateSimilarityMatrix(
+                    model=model,
+                    task=task,  # type: ignore[arg-type]
+                    similarity_metric=similarity_metric,
+                    upload_if_recomputed=upload_if_recomputed,
+                    save_outputs=True,
+                )
+                _compute_and_report(
+                    rt, hf_files, upload_if_recomputed,
+                    f"SimilarityMatrix for {model}/{task}/{similarity_metric}",
+                )
         print("")
     print("SimilarityMatrix done.")
 
@@ -426,25 +430,19 @@ def run_count_significant_relationship(
     me_list = _ALL_ME
     for model in _ALL_MODELS:
         for task in tasks:
-            try:
-                rt = vb.ResultTemplateCountSignificantRelationship(
-                    model=model,
-                    task=task,  # type: ignore[arg-type]
-                    unlearning_algorithm_list=methods,  # type: ignore[arg-type]
-                    interference_entity_list=me_list,
-                    attribute_list=list(vb.task_to_attributes_of_interest.get(task, [])),
-                    upload_if_recomputed=upload_if_recomputed,
-                    save_outputs=True,
-                )
-                if _should_skip(rt, hf_files, upload_if_recomputed):
-                    continue
-                rt.compute()
-                print(f"CountSignificantRelationship {model}/{task} OK")
-            except Exception as e:
-                logger.warning(
-                    "CountSignificantRelationship failed for %s/%s: %s",
-                    model, task, e,
-                )
+            rt = vb.ResultTemplateCountSignificantRelationship(
+                model=model,
+                task=task,  # type: ignore[arg-type]
+                unlearning_algorithm_list=methods,  # type: ignore[arg-type]
+                interference_entity_list=me_list,
+                attribute_list=list(vb.task_to_attributes_of_interest.get(task, [])),
+                upload_if_recomputed=upload_if_recomputed,
+                save_outputs=True,
+            )
+            _compute_and_report(
+                rt, hf_files, upload_if_recomputed,
+                f"CountSignificantRelationship for {model}/{task}",
+            )
     print("CountSignificantRelationship done.")
 
 
@@ -476,28 +474,21 @@ def run_implicit_association_test(
             for unlearning_algorithm in methods:
                 for latent_embedding in _ALL_L:
                     for attr1, attr2 in attribute_pairs:
-                        try:
-                            rt = vb.ResultTemplateImplicitAssociationTest(  # type: ignore[arg-type]
-                                model=model,
-                                task=task,  # type: ignore[arg-type]
-                                unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                                attribute_1=attr1,
-                                attribute_2=attr2,
-                                latent_embedding=latent_embedding,
-                                upload_if_recomputed=upload_if_recomputed,
-                                save_outputs=True,
-                            )
-                            if _should_skip(rt, hf_files, upload_if_recomputed):
-                                continue
-                            rt.compute()
-                            print(".", end="", flush=True)
-                        except Exception as e:
-                            logger.warning(
-                                "ImplicitAssociationTest failed for "
-                                "%s/%s/%s/%s/%s/%s: %s",
-                                model, task, unlearning_algorithm,
-                                latent_embedding, attr1, attr2, e,
-                            )
+                        rt = vb.ResultTemplateImplicitAssociationTest(  # type: ignore[arg-type]
+                            model=model,
+                            task=task,  # type: ignore[arg-type]
+                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                            attribute_1=attr1,
+                            attribute_2=attr2,
+                            latent_embedding=latent_embedding,
+                            upload_if_recomputed=upload_if_recomputed,
+                            save_outputs=True,
+                        )
+                        _compute_and_report(
+                            rt, hf_files, upload_if_recomputed,
+                            f"ImplicitAssociationTest for {model}/{task}/{unlearning_algorithm}/"
+                            f"{latent_embedding}/{attr1}/{attr2}",
+                        )
     print("ImplicitAssociationTest done.")
 
 
@@ -527,6 +518,9 @@ def run_interference_visual_summary(
     tasks: List[str],
     methods: List[str],
     entity_count: int = 100,
+    hf_files: FrozenSet[str] = frozenset(),
+    upload_if_recomputed: bool = False,
+    mp_list: List[vb.type_mp] = _ALL_MP,
 ) -> None:
     """InterferenceVisualSummary: (model, task, unlearning_algorithm, mp, entity_index).
 
@@ -536,26 +530,22 @@ def run_interference_visual_summary(
     """
     for task in tasks:
         for unlearning_algorithm in methods:
-            for interference_pair in _ALL_MP:
+            for interference_pair in mp_list:
                 for entity_index in range(entity_count):
-                    try:
-                        rt = vb.ResultTemplateInterferenceVisualSummary(  # type: ignore[arg-type]
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
-                            interference_pair=interference_pair,
-                            entity_index=entity_index,
-                            seed=42,
-                            save_outputs=True,
-                        )
-                        rt.compute()
-                        print(".", end="", flush=True)
-                    except Exception as e:
-                        logger.warning(
-                            "InterferenceVisualSummary failed for "
-                            "%s/%s/%s entity=%d: %s",
-                            task, unlearning_algorithm,
-                            interference_pair, entity_index, e,
-                        )
+                    rt = vb.ResultTemplateInterferenceVisualSummary(  # type: ignore[arg-type]
+                        task=task,  # type: ignore[arg-type]
+                        unlearning_algorithm=unlearning_algorithm,  # type: ignore[arg-type]
+                        interference_pair=interference_pair,
+                        entity_index=entity_index,
+                        seed=42,
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    )
+                    _compute_and_report(
+                        rt, hf_files, upload_if_recomputed,
+                        f"InterferenceVisualSummary for {task}/{unlearning_algorithm}/"
+                        f"{interference_pair} entity={entity_index}",
+                    )
                 print("")
     print("InterferenceVisualSummary done.")
 
@@ -575,24 +565,18 @@ def run_method_comparison_by_metric_entity(
     for model in _ALL_MODELS:
         for task in tasks:
             for interference_entity in me_list:
-                try:
-                    rt = vb.ResultTemplateMethodComparisonByMetricEntity(
-                        model=model,
-                        task=task,  # type: ignore[arg-type]
-                        interference_entity=interference_entity,
-                        unlearning_algorithm_list=methods,  # type: ignore[arg-type]
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
-                    if _should_skip(rt, hf_files, upload_if_recomputed):
-                        continue
-                    rt.compute()
-                    print(".", end="", flush=True)
-                except Exception as e:
-                    logger.warning(
-                        "MethodComparisonByMetricEntity failed for %s/%s/%s: %s",
-                        model, task, interference_entity, e,
-                    )
+                rt = vb.ResultTemplateMethodComparisonByMetricEntity(
+                    model=model,
+                    task=task,  # type: ignore[arg-type]
+                    interference_entity=interference_entity,
+                    unlearning_algorithm_list=methods,  # type: ignore[arg-type]
+                    upload_if_recomputed=upload_if_recomputed,
+                    save_outputs=True,
+                )
+                _compute_and_report(
+                    rt, hf_files, upload_if_recomputed,
+                    f"MethodComparisonByMetricEntity for {model}/{task}/{interference_entity}",
+                )
         print("")
     print("MethodComparisonByMetricEntity done.")
 
@@ -617,24 +601,18 @@ def run_embedding_unlearning_profile(
             for method in methods:
                 for row in metadata:
                     entity = row["name"]
-                    try:
-                        rt = vb.ResultTemplateEmbeddingUnlearningProfile(
-                            model=model,
-                            task=task,  # type: ignore[arg-type]
-                            unlearning_algorithm=method,  # type: ignore[arg-type]
-                            entity=entity,
-                            upload_if_recomputed=upload_if_recomputed,
-                            save_outputs=True,
-                        )
-                        if _should_skip(rt, hf_files, upload_if_recomputed):
-                            continue
-                        rt.compute()
-                        print(".", end="", flush=True)
-                    except Exception as e:
-                        logger.warning(
-                            "EmbeddingUnlearningProfile failed for %s/%s/%s/%s: %s",
-                            model, task, method, entity, e,
-                        )
+                    rt = vb.ResultTemplateEmbeddingUnlearningProfile(
+                        model=model,
+                        task=task,  # type: ignore[arg-type]
+                        unlearning_algorithm=method,  # type: ignore[arg-type]
+                        entity=entity,
+                        upload_if_recomputed=upload_if_recomputed,
+                        save_outputs=True,
+                    )
+                    _compute_and_report(
+                        rt, hf_files, upload_if_recomputed,
+                        f"EmbeddingUnlearningProfile for {model}/{task}/{method}/{entity}",
+                    )
                 print("")
     print("EmbeddingUnlearningProfile done.")
 
@@ -652,23 +630,17 @@ def run_embedding_forgetting_efficiency(
     for model in _ALL_MODELS:
         for task in tasks:
             for method in methods:
-                try:
-                    rt = vb.ResultTemplateEmbeddingForgettingEfficiency(
-                        model=model,
-                        task=task,  # type: ignore[arg-type]
-                        unlearning_algorithm=method,  # type: ignore[arg-type]
-                        upload_if_recomputed=upload_if_recomputed,
-                        save_outputs=True,
-                    )
-                    if _should_skip(rt, hf_files, upload_if_recomputed):
-                        continue
-                    rt.compute()
-                    print(".", end="", flush=True)
-                except Exception as e:
-                    logger.warning(
-                        "EmbeddingForgettingEfficiency failed for %s/%s/%s: %s",
-                        model, task, method, e,
-                    )
+                rt = vb.ResultTemplateEmbeddingForgettingEfficiency(
+                    model=model,
+                    task=task,  # type: ignore[arg-type]
+                    unlearning_algorithm=method,  # type: ignore[arg-type]
+                    upload_if_recomputed=upload_if_recomputed,
+                    save_outputs=True,
+                )
+                _compute_and_report(
+                    rt, hf_files, upload_if_recomputed,
+                    f"EmbeddingForgettingEfficiency for {model}/{task}/{method}",
+                )
         print("")
     print("EmbeddingForgettingEfficiency done.")
 
@@ -686,8 +658,11 @@ ALL_RT_NAMES = [
     "countsignificantrelationship",
     "implicitassociationtest",
     # "minimumcutinterference" — skipped (too many combos, on-demand only)
-    # "unlearningvisualsummary" — requires full HF dataset download; risk of throttle
-    # "interferencevisualsummary" — requires full HF dataset download; risk of throttle
+    # "unlearningvisualsummary" — excluded: ResultTemplateUnlearningVisualSummary is an
+    #   unimplemented stub (no _serialize_parameters/_compute_from_scratch/plot; calling
+    #   .compute() raises NotImplementedError). It is also not used anywhere in Forgety's
+    #   entity-browsing flow. Confirmed out of scope 2026-07-13.
+    "interferencevisualsummary",
     "methodcomparisonbymetricentity",
     "embeddingunlearningprofile",
     "embeddingforgettingefficiency",
@@ -898,6 +873,14 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--mp",
+        nargs="+",
+        default=_ALL_MP,
+        choices=_ALL_MP,
+        metavar="METRIC",
+        help="Per-pair interference metric(s) to include (default: all 5).",
+    )
+    parser.add_argument(
         "--entity-count",
         type=int,
         default=100,
@@ -989,13 +972,13 @@ def main() -> None:
                 run_metric_metric_alignment(tasks, methods, hf_files, upload)
 
             elif rt_name == "metricsimilarityalignment":
-                run_metric_similarity_alignment(tasks, methods, hf_files, upload)
+                run_metric_similarity_alignment(tasks, methods, hf_files, upload, mp_list=args.mp)
 
             elif rt_name == "metricsimilarityalignmentmulti":
-                run_metric_similarity_alignment_multi(tasks, methods, hf_files, upload)
+                run_metric_similarity_alignment_multi(tasks, methods, hf_files, upload, mp_list=args.mp)
 
             elif rt_name == "interferencematrix":
-                run_interference_matrix(tasks, methods, hf_files, upload)
+                run_interference_matrix(tasks, methods, hf_files, upload, mp_list=args.mp)
 
             elif rt_name == "similaritymatrix":
                 run_similarity_matrix(tasks, hf_files, upload)
@@ -1014,7 +997,8 @@ def main() -> None:
 
             elif rt_name == "interferencevisualsummary":
                 run_interference_visual_summary(
-                    tasks, methods, entity_count=args.entity_count
+                    tasks, methods, entity_count=args.entity_count,
+                    hf_files=hf_files, upload_if_recomputed=upload, mp_list=args.mp,
                 )
 
             elif rt_name == "methodcomparisonbymetricentity":

--- a/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
+++ b/vision_unlearning/benchmarks/I_care/pipeline_08_run_all_rts.py
@@ -216,9 +216,11 @@ def run_metric_similarity_alignment(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
-    mp_list: List[vb.type_mp] = _ALL_MP,
+    mp_list: Optional[List[vb.type_mp]] = None,
 ) -> None:
     """MetricSimilarityAlignment: (model, task, unlearning_algorithm, mp, s)."""
+    if mp_list is None:
+        mp_list = _ALL_MP
     for model in _ALL_MODELS:
         for task in tasks:
             for unlearning_algorithm in methods:
@@ -247,7 +249,7 @@ def run_metric_similarity_alignment_multi(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
-    mp_list: List[vb.type_mp] = _ALL_MP,
+    mp_list: Optional[List[vb.type_mp]] = None,
 ) -> None:
     """MetricSimilarityAlignmentMulti: (model, task, unlearning_algorithm, mp, s_list, reg_algo).
 
@@ -255,6 +257,8 @@ def run_metric_similarity_alignment_multi(
     The combined run (clip+dino+jacc) is the primary analysis; the individual-metric
     runs (clip-only, dino-only, jacc-only) serve as within-model baselines.
     """
+    if mp_list is None:
+        mp_list = _ALL_MP
     all_metrics = _ALL_S
     regression_algorithms = _ALL_REG_ALGOS
     similarity_sets = [all_metrics]  # primary: all combined
@@ -292,9 +296,11 @@ def run_interference_matrix(
     methods: List[str],
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
-    mp_list: List[vb.type_mp] = _ALL_MP,
+    mp_list: Optional[List[vb.type_mp]] = None,
 ) -> None:
     """InterferenceMatrix: (model, task, unlearning_algorithm, interference_pair)."""
+    if mp_list is None:
+        mp_list = _ALL_MP
     for model in _ALL_MODELS:
         for task in tasks:
             for unlearning_algorithm in methods:
@@ -527,7 +533,7 @@ def run_interference_visual_summary(
     entity_count: int = 100,
     hf_files: FrozenSet[str] = frozenset(),
     upload_if_recomputed: bool = False,
-    mp_list: List[vb.type_mp] = _ALL_MP,
+    mp_list: Optional[List[vb.type_mp]] = None,
 ) -> None:
     """InterferenceVisualSummary: (model, task, unlearning_algorithm, mp, entity_index).
 
@@ -535,6 +541,8 @@ def run_interference_visual_summary(
         entity_count: how many entity indices to run (default 100, matching
                       the notebook's ``range(0, 100)``).
     """
+    if mp_list is None:
+        mp_list = _ALL_MP
     for task in tasks:
         for unlearning_algorithm in methods:
             for interference_pair in mp_list:
@@ -882,7 +890,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mp",
         nargs="+",
-        default=_ALL_MP,
+        default=list(_ALL_MP),
         choices=_ALL_MP,
         metavar="METRIC",
         help="Per-pair interference metric(s) to include (default: all 5).",


### PR DESCRIPTION
## Summary
- `InterferenceVisualSummary` could not be selected via `pipeline_08_run_all_rts.py --rts` (excluded from `ALL_RT_NAMES`), and its runner never threaded `upload_if_recomputed`/`hf_files` through to the RT constructor the way every other runner did.
- Extracted the repeated skip/compute/progress/warn block (duplicated across 9 of 11 runners) into one `_compute_and_report` helper, wired into all 9 (the two exceptions — `run_significant_relationship` and `run_unlearning_visual_summary` — are explained in code comments).
- Registered `interferencevisualsummary` in `ALL_RT_NAMES`; gave its runner the same HF upload/skip wiring every other runner already has.
- Added a generalized `--mp` flag restricting which per-pair interference metric(s) are computed, threaded into the four runners that previously hardcoded all 5 metrics.
- Fixed a pre-existing indentation bug in `run_interference_matrix` (blank-line separator printed one loop level too early).
- Clarified why `UnlearningVisualSummary` stays excluded (unimplemented stub, not a throttling precaution).

## Test plan
- [x] `make test-lite` (mypy + pycodestyle + pytest) green: 250 passed, 4 skipped
- [x] New unit tests for `_should_skip`, `_compute_and_report`, `resolve_rt_names`, and `--mp`
- [x] Real end-to-end run of the new `InterferenceVisualSummary` CLI path against 32 `people/distil` entities — all succeeded, producing correct JSON results (~650KB each, matching the expected size), images decoded and visually spot-checked
- [x] `EmbeddingUnlearningProfile` smoke test (100 `people/distil` entities) confirms the refactor didn't change its already-correct behavior

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>